### PR TITLE
text-bison001では動作しないのでtext-bisonに変更する必要がある。

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -27,7 +27,7 @@ parameters = {
 def hello_world():
 
     vertexai.init(location="us-central1")
-    model = TextGenerationModel.from_pretrained("text-bison@001")
+    model = TextGenerationModel.from_pretrained("text-bison")
     response = model.predict(
         "Who are you?",
         **parameters


### PR DESCRIPTION

CloudRunでGETリクエストを送った時に504エラーが出るので原因を調査したところ
モデル名の指定が良くなかったことが判明した。

元のモデル名：「text-bison＠001」
変更後のモデル名：「text-bison」